### PR TITLE
No camel case conversions

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -7,9 +7,9 @@ var lint = require('jshint').JSHINT;
 var _ = require('lodash');
 var typeConversion = require('./typeConversion');
 
-var getPathToMethodName = function(m, path){
+var getPathToMethodName = function(httpMethod, path){
     if(path === '/' || path === '') {
-        return m;
+        return httpMethod;
     }
 
     // clean url path for requests ending with '/'
@@ -21,12 +21,13 @@ var getPathToMethodName = function(m, path){
     var segments = cleanPath.split('/').slice(1);
     segments = _.transform(segments, function (result, segment) {
         if (segment[0] === '{' && segment[segment.length - 1] === '}') {
-            segment = 'by' + segment[1].toUpperCase() + segment.substring(2, segment.length - 1);
+            segment = 'By' + segment[1].toUpperCase() + segment.substring(2, segment.length - 1);
         }
         result.push(segment);
     });
-    var result = segments.join('-');
-    return m.toLowerCase() + result[0].toUpperCase() + result.substring(1);
+    var result = segments.join();
+
+    return httpMethod.toLowerCase() + result[0].toUpperCase() + result.substring(1);
 };
 
 var getViewForSwagger2 = function(opts, type){
@@ -47,23 +48,23 @@ var getViewForSwagger2 = function(opts, type){
         var globalParams = [];
         /**
          * @param {Object} op - meta data for the request
-         * @param {string} m - HTTP method name - eg: 'get', 'post', 'put', 'delete'
+         * @param {string} httpMethod - HTTP method name - eg: 'get', 'post', 'put', 'delete'
          */
-        _.forEach(api, function(op, m){
-            if(m.toLowerCase() === 'parameters') {
+        _.forEach(api, function(op, httpMethod){
+            if(httpMethod.toLowerCase() === 'parameters') {
                 globalParams = op;
             }
         });
-        _.forEach(api, function(op, m){
-            if(authorizedMethods.indexOf(m.toUpperCase()) === -1) {
+        _.forEach(api, function(op, httpMethod){
+            if(authorizedMethods.indexOf(httpMethod.toUpperCase()) === -1) {
                 return;
             }
             var method = {
                 path: path,
                 className: opts.className,
-                methodName: op['x-swagger-js-method-name'] ? op['x-swagger-js-method-name'] : (op.operationId ? op.operationId : getPathToMethodName(m, path)),
-                method: m.toUpperCase(),
-                isGET: m.toUpperCase() === 'GET',
+                methodName: op['x-swagger-js-method-name'] ? op['x-swagger-js-method-name'] : (op.operationId ? op.operationId : getPathToMethodName(httpMethod, path)),
+                method: httpMethod.toUpperCase(),
+                isGET: httpMethod.toUpperCase() === 'GET',
                 summary: op.description,
                 isSecure: op.security !== undefined,
                 parameters: []

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -7,21 +7,6 @@ var lint = require('jshint').JSHINT;
 var _ = require('lodash');
 var typeConversion = require('./typeConversion');
 
-var camelCase = function(id) {
-    if(id.indexOf('-') === -1) {
-        return id;
-    }
-    var tokens = [];
-    id.split('-').forEach(function(token, index){
-        if(index === 0) {
-            tokens.push(token[0].toLowerCase() + token.substring(1));
-        } else {
-            tokens.push(token[0].toUpperCase() + token.substring(1));
-        }
-    });
-    return tokens.join('');
-};
-
 var getPathToMethodName = function(m, path){
     if(path === '/' || path === '') {
         return m;
@@ -40,7 +25,7 @@ var getPathToMethodName = function(m, path){
         }
         result.push(segment);
     });
-    var result = camelCase(segments.join('-'));
+    var result = segments.join('-');
     return m.toLowerCase() + result[0].toUpperCase() + result.substring(1);
 };
 
@@ -98,7 +83,7 @@ var getViewForSwagger2 = function(opts, type){
                     var segments = parameter.$ref.split('/');
                     parameter = swagger.parameters[segments.length === 1 ? segments[0] : segments[2] ];
                 }
-                parameter.camelCaseName = camelCase(parameter.name);
+
                 if(parameter.enum && parameter.enum.length === 1) {
                     parameter.isSingleton = true;
                     parameter.singleton = parameter.enum[0];
@@ -173,7 +158,6 @@ var getViewForSwagger1 = function(opts, type){
             };
             op.parameters = op.parameters ? op.parameters : [];
             op.parameters.forEach(function(parameter) {
-                parameter.camelCaseName = camelCase(parameter.name);
                 if(parameter.enum && parameter.enum.length === 1) {
                     parameter.isSingleton = true;
                     parameter.singleton = parameter.enum[0];

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -46,15 +46,15 @@
                     });
                 {{/isPatternType}}
                 {{^isPatternType}}
-                if(parameters['{{&camelCaseName}}'] !== undefined){
-                    queryParameters['{{&name}}'] = parameters['{{&camelCaseName}}'];
+                if(parameters['{{&name}}'] !== undefined){
+                    queryParameters['{{&name}}'] = parameters['{{&name}}'];
                 }
                 {{/isPatternType}}
             {{/isSingleton}}
         {{/isQueryParameter}}
         
         {{#isPathParameter}}
-            path = path.replace('{{=<% %>=}}{<%&name%>}<%={{ }}=%>', parameters['{{&camelCaseName}}']);
+            path = path.replace('{{=<% %>=}}{<%&name%>}<%={{ }}=%>', parameters['{{&name}}']);
         {{/isPathParameter}}
         
         {{#isHeaderParameter}}
@@ -62,15 +62,15 @@
                 headers['{{&name}}'] = '{{&singleton}}';
             {{/isSingleton}}
             {{^isSingleton}}
-                if(parameters['{{&camelCaseName}}'] !== undefined){
-                    headers['{{&name}}'] = parameters['{{&camelCaseName}}'];
+                if(parameters['{{&name}}'] !== undefined){
+                    headers['{{&name}}'] = parameters['{{&name}}'];
                 }
             {{/isSingleton}}
         {{/isHeaderParameter}}
         
         {{#isBodyParameter}}
-            if(parameters['{{&camelCaseName}}'] !== undefined){
-                body = parameters['{{&camelCaseName}}'];
+            if(parameters['{{&name}}'] !== undefined){
+                body = parameters['{{&name}}'];
             }
         {{/isBodyParameter}}
 
@@ -79,15 +79,15 @@
                 form['{{&name}}'] = '{{&singleton}}';
             {{/isSingleton}}
             {{^isSingleton}}
-                if(parameters['{{&camelCaseName}}'] !== undefined){
-                    form['{{&name}}'] = parameters['{{&camelCaseName}}'];
+                if(parameters['{{&name}}'] !== undefined){
+                    form['{{&name}}'] = parameters['{{&name}}'];
                 }
             {{/isSingleton}}
         {{/isFormParameter}}
 
         {{#required}}
-        if(parameters['{{&camelCaseName}}'] === undefined){
-            deferred.reject(new Error('Missing required {{&paramType}} parameter: {{&camelCaseName}}'));
+        if(parameters['{{&name}}'] === undefined){
+            deferred.reject(new Error('Missing required {{&paramType}} parameter: {{&name}}'));
             return deferred.promise;
         }
         {{/required}}

--- a/templates/method.mustache
+++ b/templates/method.mustache
@@ -3,7 +3,7 @@
  * @method
  * @name {{&className}}#{{&methodName}}
 {{#parameters}}
-{{^isSingleton}} * @param {{=<% %>=}}{<%&type%>}<%={{ }}=%> {{&camelCaseName}} - {{&description}}{{/isSingleton}}
+{{^isSingleton}} * @param {{=<% %>=}}{<%&type%>}<%={{ }}=%> {{&name}} - {{&description}}{{/isSingleton}}
 {{/parameters}}
  * 
  */

--- a/tests/apis/petstore-simple.json
+++ b/tests/apis/petstore-simple.json
@@ -185,6 +185,9 @@
                 "name": {
                     "type": "string"
                 },
+                "owner-name": {
+                    "type": "string"
+                },
                 "tag": {
                     "type": "string"
                 }
@@ -200,6 +203,9 @@
                     "format": "int64"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "owner-name": {
                     "type": "string"
                 },
                 "tag": {

--- a/tests/expected/petstore-simple.d.ts
+++ b/tests/expected/petstore-simple.d.ts
@@ -25,12 +25,14 @@ interface Petstore {
 interface pet {
     'id': number
     'name': string
+    'owner-name': string
     'tag': string
 }
 
 interface newPet {
     'id': number
     'name': string
+    'owner-name': string
     'tag': string
 }
 


### PR DESCRIPTION
I noticed that parameters passed into methods were being converted from camelCase to hyphenated-words, but as far as I could see there was no similar translation when a type was being returned from the server.  So, if the same type was being used as an input and an output of a method, and contained hyphenated parameters, it could not compile.